### PR TITLE
feat: use environment variable for ngrok token

### DIFF
--- a/CASE APP/README.md
+++ b/CASE APP/README.md
@@ -1,0 +1,17 @@
+# CASE APP
+
+## Configuração
+
+Defina a variável de ambiente `NGROK_API_TOKEN` com o token da API do ngrok antes de iniciar a aplicação.
+
+```bash
+export NGROK_API_TOKEN=seu_token_aqui
+```
+
+No Windows (PowerShell):
+
+```powershell
+$env:NGROK_API_TOKEN="seu_token_aqui"
+```
+
+A aplicação utilizará este token para consultar o endpoint do ngrok.

--- a/CASE APP/src/db/urServer.js
+++ b/CASE APP/src/db/urServer.js
@@ -5,7 +5,12 @@ let urlServer = "";
 
 async function fetchUrl() {
   const apiUrl = "https://api.ngrok.com/endpoints";
-  const token = "2lvQmJBLJqewAOCTj6X1l2Ix0R5_7i6WoH8DmcuVjgXhNip3Q";
+  const token = process.env.NGROK_API_TOKEN;
+
+  if (!token) {
+    console.error("NGROK_API_TOKEN is not defined");
+    return;
+  }
 
   try {
     const response = await fetch(apiUrl, {


### PR DESCRIPTION
## Summary
- load ngrok API token from NGROK_API_TOKEN environment variable
- document NGROK_API_TOKEN setup

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b277634e148332bbff6f0b2c431c8a