### PR TITLE
Use environment JWT secret with startup enforcement

### DIFF
--- a/Server App/package.json
+++ b/Server App/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "start": "node -e \"if(!process.env.JWT_SECRET){console.error('JWT_SECRET environment variable is required');process.exit(1);} require('./server.js');\""
   },
   "author": "Anglei Ferreira Ferradais",
   "license": "ISC",

--- a/Server App/server.js
+++ b/Server App/server.js
@@ -3,6 +3,7 @@ const jwt = require("jsonwebtoken");
 const express = require("express");
 const cors = require("cors");
 const fs = require("fs");
+const crypto = require("crypto");
 //AES-128-ECB - case => base64
 
 const app = express();
@@ -25,7 +26,12 @@ const departamentoPath = "./database/departamentos.json";
 let departamentoP = {};
 
 const secretKey =
-  "cG0xVFplLWhYOGJ0cUhCNmdEcUYyVEJleWk5NWZGQTFjajZLQWZHREFxRQ==";
+  process.env.JWT_SECRET || crypto.randomBytes(64).toString("base64");
+if (!process.env.JWT_SECRET) {
+  console.warn(
+    "JWT_SECRET environment variable is not set. Using a generated fallback key."
+  );
+}
 
 function recarregarDados() {
   try {

--- a/Server App/start.bat
+++ b/Server App/start.bat
@@ -1,3 +1,8 @@
 @echo off
+if "%JWT_SECRET%"=="" (
+  echo JWT_SECRET environment variable is required.
+  exit /b 1
+)
 start cmd /k "node server.js"
 start cmd /k "ngrok http --host-header=rewrite 3000"
+


### PR DESCRIPTION
## Summary
- Read JWT secret from `JWT_SECRET` env var with secure fallback
- Require `JWT_SECRET` for npm and batch startup scripts

## Testing
- `npm test`
- `npm start` *(fails without `JWT_SECRET`)*

------
https://chatgpt.com/codex/tasks/task_e_68b2781df224833288eba8272216ae37