### PR TITLE
refactor: use async fs in order routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/node_modules/


### PR DESCRIPTION
## Summary
- refactor order routes to use async fs and improved HTTP error handling
- ignore node_modules directories

## Testing
- `node --check 'Server App/server.js'`
- `cd 'Server App' && npm test` (fails: `Error: no test specified`)


------
https://chatgpt.com/codex/tasks/task_e_68b278e19fdc8332bafbf452bdcccbe3