### PR TITLE
refactor: externalize secrets and async fs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/node_modules/
+.env

--- a/CASE APP/src/controllers/addpedido.js
+++ b/CASE APP/src/controllers/addpedido.js
@@ -2,7 +2,11 @@ let urlServer = "";
 
 document.addEventListener("DOMContentLoaded", async function () {
   fetch("../db/data.json")
-    .then((response) => response.json())
+    .then((response) => {
+      if (!response.ok)
+        throw new Error(`Erro ao carregar o JSON: ${response.status}`);
+      return response.json();
+    })
     .then(async (data) => {
       try {
         urlServer = "https://" + data.urlServer;
@@ -52,13 +56,15 @@ document.addEventListener("DOMContentLoaded", async function () {
             "Content-Type": "application/json",
           },
         })
-          .then((response) => response.json())
+          .then((response) => {
+            if (!response.ok)
+              throw new Error(`Erro ao obter contratos: ${response.status}`);
+            return response.json();
+          })
           .then((data) => {
             const arrayContratos = Object.values(data);
-            console.log(arrayContratos)
             const selectElement = document.getElementById("contratos-select");
             arrayContratos.forEach((contrato) => {
-              console.log(contrato)
               const option = document.createElement("option");
               option.text = contrato;
               option.value = contrato;
@@ -67,7 +73,6 @@ document.addEventListener("DOMContentLoaded", async function () {
           })
           .catch((error) => {
             console.error("Erro ao obter contratos:", error);
-            // Trate o erro conforme necessário
           });
         concluirButton.addEventListener("click", function (event) {
           event.preventDefault();
@@ -78,7 +83,13 @@ document.addEventListener("DOMContentLoaded", async function () {
               "ngrok-skip-browser-warning": "69420",
             },
           })
-            .then((response) => response.json())
+            .then((response) => {
+              if (!response.ok)
+                throw new Error(
+                  `Erro ao obter quantidade de pedidos: ${response.status}`
+                );
+              return response.json();
+            })
             .then((data) => {
               idT = data.idPedido;
               const contrato =
@@ -94,7 +105,6 @@ document.addEventListener("DOMContentLoaded", async function () {
                 return;
               }
 
-              console.log(idT);
               // Crie um FormData específico para o formulário principal
               const formData = new FormData(
                 document.getElementById("pedidoForm")
@@ -150,7 +160,6 @@ document.addEventListener("DOMContentLoaded", async function () {
                 return;
               }
 
-              console.log('teste')
               // Enviar a solicitação POST para adicionar o novo pedido
               fetch(`${urlServer}/adicionar-pedido`, {
                 method: "POST",
@@ -166,15 +175,17 @@ document.addEventListener("DOMContentLoaded", async function () {
                   id: idT,
                 }),
               })
-                .then((response) => response.json())
-                .then((data) => {
-                  console.log('teste')
-                  console.log("Novo pedido adicionado:", data);
-
+                .then((response) => {
+                  if (!response.ok)
+                    throw new Error(
+                      `Erro ao adicionar o pedido: ${response.status}`
+                    );
+                  return response.json();
+                })
+                .then(() => {
                   window.location.href = `${pagelink}`;
                 })
                 .catch((error) => {
-                  console.log('teste')
                   console.error("Erro ao adicionar o pedido:", error);
                 });
             })

--- a/CASE APP/src/controllers/listpedido.js
+++ b/CASE APP/src/controllers/listpedido.js
@@ -2,7 +2,11 @@ let urlServer2 = "";
 
 document.addEventListener("DOMContentLoaded", async function () {
   fetch("../db/data.json")
-    .then((response) => response.json())
+    .then((response) => {
+      if (!response.ok)
+        throw new Error(`Erro ao carregar o JSON: ${response.status}`);
+      return response.json();
+    })
     .then(async (data) => {
       try {
         urlServer2 = "https://" + data.urlServer;
@@ -20,7 +24,13 @@ document.addEventListener("DOMContentLoaded", async function () {
               Authorization: token,
             },
           })
-            .then((response) => response.json())
+            .then((response) => {
+              if (!response.ok)
+                throw new Error(
+                  `Erro ao obter os pedidos: ${response.status}`
+                );
+              return response.json();
+            })
             .then((pedidos) => {
               const dataTable = $(".datanew").DataTable();
 

--- a/CASE APP/src/controllers/login.js
+++ b/CASE APP/src/controllers/login.js
@@ -1,41 +1,45 @@
 let urlServer1 = "";
 
-fetch("./src/db/data.json")
-  .then((response) => response.json())
-  .then(async (data) => {
-    try {
-      urlServer1 = "https://" + data.urlServer;
-      document.getElementById("loginButton").addEventListener("click", login);
+async function init() {
+  try {
+    const response = await fetch("./src/db/data.json");
+    if (!response.ok) throw new Error(`Erro HTTP ${response.status}`);
+    const data = await response.json();
+    urlServer1 = `https://${data.urlServer}`;
+    document.getElementById("loginButton").addEventListener("click", login);
+  } catch (error) {
+    console.error("Erro ao carregar o JSON:", error);
+  }
+}
 
-      async function login() {
-        const matricula = document.getElementById("emailMatricula").value;
-        const senha = document.getElementById("senha").value;
+async function login() {
+  const matricula = document.getElementById("emailMatricula").value;
+  const senha = document.getElementById("senha").value;
 
-        try {
-          const response = await fetch(`${urlServer1}/login`, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({ matricula, senha }),
-          });
+  try {
+    const response = await fetch(`${urlServer1}/login`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ matricula, senha }),
+    });
+    if (!response.ok) throw new Error(`Erro HTTP ${response.status}`);
 
-          const data = await response.json();
+    const data = await response.json();
 
-          if (data.success) {
-            sessionStorage.setItem("token", data.token);
-            sessionStorage.setItem("user", JSON.stringify(data.user));
-            sessionStorage.setItem("menuItems", data.menuItems);
-            sessionStorage.setItem("pageIndex", data.redirectURL);
-            window.location.href = data.redirectURL;
-          } else {
-            alert("Credenciais inválidas");
-          }
-        } catch (error) {
-          console.error("Erro durante o login:", error);
-        }
-      }
-    } catch (error) {
-      console.error("Erro ao carregar o JSON:", error);
+    if (data.success) {
+      sessionStorage.setItem("token", data.token);
+      sessionStorage.setItem("user", JSON.stringify(data.user));
+      sessionStorage.setItem("menuItems", JSON.stringify(data.menuItems));
+      sessionStorage.setItem("pageIndex", data.redirectURL);
+      window.location.href = data.redirectURL;
+    } else {
+      alert("Credenciais inválidas");
     }
-  });
+  } catch (error) {
+    console.error("Erro durante o login:", error);
+  }
+}
+
+init();

--- a/CASE APP/src/css/style.css
+++ b/CASE APP/src/css/style.css
@@ -6647,7 +6647,7 @@ td a img {
 }
 .product-lists {
   border: 1px solid #fafbfe;
-  box-shadow: 0 4px 4px 0 #ededed40;
+  box-shadow: 0 4px 4px 0 rgba(237, 237, 237, 0.25);
   margin: 0 0 15px;
   padding: 15px;
 }
@@ -7003,7 +7003,7 @@ td a img {
   height: 25px;
   margin-right: 8px;
   vertical-align: 0;
-  border: 3px solid #fc88037d;
+  border: 3px solid rgba(252, 136, 3, 0.49);
   border-right-color: #0079ff;
   animation: 0.75s linear infinite spinner-border;
   border-radius: 50%;
@@ -7029,7 +7029,7 @@ td a img {
   background: #fff;
   border-radius: 5px;
   padding: 10px;
-  box-shadow: 0 4px 4px 0 #ededed40;
+  box-shadow: 0 4px 4px 0 rgba(237, 237, 237, 0.25);
   border: 1px solid #f8f8f8 !important;
   height: 105px;
   flex-direction: column;
@@ -7142,7 +7142,7 @@ td a img {
 }
 .order-list .actionproducts > ul > li .deletebg {
   background: #fff;
-  box-shadow: 0 4px 14px 0 #c7c7c740;
+  box-shadow: 0 4px 14px 0 rgba(199, 199, 199, 0.25);
   width: 30px;
   height: 30px;
   border-radius: 5px;
@@ -7152,7 +7152,7 @@ td a img {
 }
 .productset {
   border: 1px solid #f8f8f8;
-  box-shadow: 0 4px 4px 0 #ededed40;
+  box-shadow: 0 4px 4px 0 rgba(237, 237, 237, 0.25);
   background: #fff;
   margin: 0 0 25px;
   border-radius: 5px;
@@ -7293,7 +7293,7 @@ td a img {
   position: relative;
   border: 10px solid #fff;
   border-radius: 50%;
-  box-shadow: 0 4px 4px 0 #00000040;
+  box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25);
 }
 .profile-set .profile-top .profile-contentimg img {
   border-radius: 50px;

--- a/CASE APP/src/css/stylePedido.css
+++ b/CASE APP/src/css/stylePedido.css
@@ -30,6 +30,10 @@ body {
   margin: 20px;
 }
 
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 #ordemCompra {
   max-width: 800px;
   margin: 0 auto;
@@ -58,6 +62,7 @@ table {
   width: 100%;
   border-collapse: collapse;
   margin-top: 20px;
+  table-layout: fixed;
 }
 
 th,
@@ -66,10 +71,11 @@ td {
   padding: 8px;
   text-align: left;
   font-size: 10px;
+  word-break: break-word;
 }
 
 th {
-  background-color: #084e6e15; /* Azul Petróleo Fraco para os títulos da tabela */
+  background-color: rgba(8, 78, 110, 0.08); /* Azul Petróleo Fraco para os títulos da tabela */
 }
 
 .logo-container {
@@ -106,6 +112,7 @@ th {
 .info-item {
   flex: 1;
   margin: 0 10px;
+  min-width: 200px;
 }
 
 .info-item p {
@@ -137,4 +144,13 @@ th {
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+@media (max-width: 600px) {
+  .info-container {
+    flex-direction: column;
+  }
+  .info-item {
+    margin: 10px 0;
+  }
 }

--- a/CASE APP/src/db/urServer.js
+++ b/CASE APP/src/db/urServer.js
@@ -1,11 +1,16 @@
-const fs = require("fs");
+const fs = require("fs/promises");
 const path = require("path");
 
 let urlServer = "";
 
 async function fetchUrl() {
   const apiUrl = "https://api.ngrok.com/endpoints";
-  const token = "2lvQmJBLJqewAOCTj6X1l2Ix0R5_7i6WoH8DmcuVjgXhNip3Q";
+  const token = process.env.NGROK_API_TOKEN;
+
+  if (!token) {
+    console.error("NGROK_API_TOKEN não definido nas variáveis de ambiente");
+    return;
+  }
 
   try {
     const response = await fetch(apiUrl, {
@@ -16,6 +21,11 @@ async function fetchUrl() {
     });
 
     const data = await response.json();
+    if (!data.endpoints || data.endpoints.length === 0) {
+      console.error("Nenhum endpoint encontrado na API Ngrok");
+      return;
+    }
+
     urlServer = String(data.endpoints[0].hostport);
   } catch (error) {
     console.error(error);
@@ -35,7 +45,7 @@ async function saveToJson() {
   const filePath = path.join(__dirname, "data.json");
 
   try {
-    await fs.promises.writeFile(filePath, JSON.stringify(jsonData, null, 2));
+    await fs.writeFile(filePath, JSON.stringify(jsonData, null, 2));
     console.log("Data foi salva em data.json");
   } catch (error) {
     console.error("Error ao salvar data em data.json:", error);

--- a/CASE APP/src/pages/addproduct.html
+++ b/CASE APP/src/pages/addproduct.html
@@ -368,20 +368,22 @@
       </div>
 
       <div class="content">
-        <div class="col-lg-12">
-          <button
-            type="button"
-            class="btn btn-submit me-2"
-            id="adicionarItemBtn"
-          >
-            Adicionar Item
-          </button>
-          <button type="button" class="btn btn-submit me-2" id="concluirBtn">
-            Concluir
-          </button>
-          <button type="button" class="btn btn-cancel" id="cancelarBtn">
-            Cancelar
-          </button>
+        <div class="row">
+          <div class="col-lg-12 text-end">
+            <button
+              type="button"
+              class="btn btn-submit me-2"
+              id="adicionarItemBtn"
+            >
+              Adicionar Item
+            </button>
+            <button type="button" class="btn btn-submit me-2" id="concluirBtn">
+              Concluir
+            </button>
+            <button type="button" class="btn btn-cancel" id="cancelarBtn">
+              Cancelar
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/CASE APP/src/pages/comercial.html
+++ b/CASE APP/src/pages/comercial.html
@@ -509,20 +509,22 @@
       </div>
 
       <div class="content">
-        <div class="col-lg-12">
-          <button
-            type="button"
-            class="btn btn-submit me-2"
-            id="adicionarItemBtn"
-          >
-            Adicionar Item
-          </button>
-          <button type="button" class="btn btn-submit me-2" id="concluirBtn">
-            Concluir
-          </button>
-          <button type="button" class="btn btn-cancel" id="cancelarBtn">
-            Cancelar
-          </button>
+        <div class="row">
+          <div class="col-lg-12 text-end">
+            <button
+              type="button"
+              class="btn btn-submit me-2"
+              id="adicionarItemBtn"
+            >
+              Adicionar Item
+            </button>
+            <button type="button" class="btn btn-submit me-2" id="concluirBtn">
+              Concluir
+            </button>
+            <button type="button" class="btn btn-cancel" id="cancelarBtn">
+              Cancelar
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/Server App/server.js
+++ b/Server App/server.js
@@ -2,11 +2,11 @@ const chokidar = require("chokidar");
 const jwt = require("jsonwebtoken");
 const express = require("express");
 const cors = require("cors");
-const fs = require("fs");
+const fs = require("fs/promises");
 //AES-128-ECB - case => base64
 
 const app = express();
-const port = 3000;
+const port = process.env.PORT || 3000;
 
 app.use(express.json());
 app.use(cors());
@@ -24,21 +24,24 @@ let colaboradoresP = {};
 const departamentoPath = "./database/departamentos.json";
 let departamentoP = {};
 
-const secretKey =
-  "cG0xVFplLWhYOGJ0cUhCNmdEcUYyVEJleWk5NWZGQTFjajZLQWZHREFxRQ==";
+const secretKey = process.env.JWT_SECRET;
+if (!secretKey) {
+  console.error("JWT_SECRET não definido nas variáveis de ambiente.");
+  process.exit(1);
+}
 
-function recarregarDados() {
+async function recarregarDados() {
   try {
-    const data0 = fs.readFileSync(ContratosPath);
+    const data0 = await fs.readFile(ContratosPath, "utf-8");
     contratos = JSON.parse(data0);
-  
-    const data1 = fs.readFileSync(usuariosPath);
+
+    const data1 = await fs.readFile(usuariosPath, "utf-8");
     usuarios = JSON.parse(data1);
-  
-    const data2 = fs.readFileSync(colaboradoresPath);
+
+    const data2 = await fs.readFile(colaboradoresPath, "utf-8");
     colaboradoresP = JSON.parse(data2);
-  
-    const data3 = fs.readFileSync(departamentoPath);
+
+    const data3 = await fs.readFile(departamentoPath, "utf-8");
     departamentoP = JSON.parse(data3);
 
     console.log("Dados recarregados com sucesso!");
@@ -47,7 +50,7 @@ function recarregarDados() {
   }
 }
 
-recarregarDados()
+recarregarDados();
 
 // Rota de login
 app.post("/login", (req, res) => {
@@ -84,7 +87,7 @@ app.post("/login", (req, res) => {
 });
 
 // Rota para adicionar pedidos
-app.post("/adicionar-pedido", verifyToken, (req, res) => {
+app.post("/adicionar-pedido", verifyToken, async (req, res) => {
   try {
     const { contrato, colaborador, pedido, id } = req.body;
 
@@ -120,7 +123,10 @@ app.post("/adicionar-pedido", verifyToken, (req, res) => {
 
     contratos.count = id;
 
-    fs.writeFileSync(ContratosPath, JSON.stringify(contratos, null, 2));
+    await fs.writeFile(
+      ContratosPath,
+      JSON.stringify(contratos, null, 2)
+    );
 
     res.json(contratos);
   } catch (error) {
@@ -130,7 +136,7 @@ app.post("/adicionar-pedido", verifyToken, (req, res) => {
 });
 
 // Rota para assinar e enviar informações atualizadas
-app.post("/assinar-pedido", verifyToken, (req, res) => {
+app.post("/assinar-pedido", verifyToken, async (req, res) => {
   try {
     const { contrato, colaborador, idPedido, quantidadesAtualizadas } =
       req.body;
@@ -164,7 +170,10 @@ app.post("/assinar-pedido", verifyToken, (req, res) => {
       });
 
       // Salve as alterações no arquivo JSON
-      fs.writeFileSync(ContratosPath, JSON.stringify(contratos, null, 2));
+      await fs.writeFile(
+        ContratosPath,
+        JSON.stringify(contratos, null, 2)
+      );
 
       res.json({ message: "Pedido assinado com sucesso." });
     } else {
@@ -327,12 +336,9 @@ app.get("/detalhes-pedido/:id", verifyToken, (req, res) => {
 app.delete(
   "/deletar-pedido/:contrato/:colaborador/:idPedido",
   verifyToken,
-  (req, res) => {
+  async (req, res) => {
     try {
       const { contrato, colaborador, idPedido } = req.params;
-
-      const data = fs.readFileSync(ContratosPath);
-      const contratos = JSON.parse(data);
 
       // Verificar se o contrato e o colaborador existem
       if (
@@ -353,7 +359,10 @@ app.delete(
           pedidos.splice(index, 1);
 
           // Salvar as alterações no arquivo JSON
-          fs.writeFileSync(ContratosPath, JSON.stringify(contratos, null, 2));
+          await fs.writeFile(
+            ContratosPath,
+            JSON.stringify(contratos, null, 2)
+          );
 
           res.json({ message: "Pedido excluído com sucesso." });
         } else {
@@ -371,9 +380,10 @@ app.delete(
   }
 );
 
-const watcher = chokidar.watch([usuariosPath, colaboradoresPath], {
-  ignoreInitial: true,
-});
+const watcher = chokidar.watch(
+  [usuariosPath, colaboradoresPath, ContratosPath, departamentoPath],
+  { ignoreInitial: true }
+);
 
 // Adicione um evento para recarregar os dados quando os arquivos forem alterados
 watcher.on("change", (path) => {


### PR DESCRIPTION
## Summary
- load Ngrok token from environment instead of hardcoding
- externalize JWT secret and replace blocking fs calls with async versions
- ignore node_modules and env files
- unify async file handling, watch all data files, and fix order deletion persistence
- add endpoint safety checks when retrieving Ngrok server address
- harden client controllers with HTTP status checks and clean session storage handling
- replace 8-digit hex colors with RGBA and refine print layout for better cross-browser and responsive styling
- align order form action buttons within a row for consistent placement

## Testing
- `npm test` (Server App) *(fails: Error: no test specified)*
- `npm test` (CASE APP) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b2763f50b88332a58d4bc6a43adaac